### PR TITLE
Fix typo bug

### DIFF
--- a/pyghthouse/ph.py
+++ b/pyghthouse/ph.py
@@ -160,7 +160,7 @@ class Pyghthouse:
 
         @staticmethod
         def print_warning(msg):
-            print(f"Warning: {msg['RNUM']} {msg['RESPONSE']} {', '.join(msg['WARNIGS'])}")
+            print(f"Warning: {msg['RNUM']} {msg['RESPONSE']} {', '.join(msg['WARNINGS'])}")
 
     class PHThread(Thread):
 


### PR DESCRIPTION
When using the library without login credentials (empty strings, probably invalid credentials in general) python prints several errors to the console, the key one being: `KeyError: 'WARNIGS'` in `ph.py`. This is caused by a typo which this PR fixes. With the fix applied we instead get:
```
Connected to wss://lighthouse.uni-kiel.de/websocket.
Warning: 401 Unauthorized 
```
which is much more helpful feedback for the developer using the library ;)